### PR TITLE
Ignore image files inside tools folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+#Pictures in Tools folder (but no subfolders)
+Tools/*.png
+Tools/*.svg
+!Tools/*/*.svg
+!Tools/*/*.png


### PR DESCRIPTION
This is because the tools need the pics to be there in the same folder. So to prevent adding icons there by mistake this could be useful.
